### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -36,6 +36,8 @@ jobs:
     needs:
       - test_release_dev
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       created_release_version: ${{ steps.get_release_dev_version.outputs.result }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/6](https://github.com/vorobalek/autobackend/security/code-scanning/6)

To fix the problem, add a `permissions` block to the `create_release_dev` job in `.github/workflows/release_dev.yml`, restricting the GITHUB_TOKEN to the minimal set of privileges necessary. The other jobs in this workflow use `permissions: contents: read`, which is a safe default. There is no indication from the job steps (it calls a script that checks releases via GitHub API but does not write or modify contents, create releases, or interact with issues) that greater privileges are needed. Therefore, `permissions: contents: read` should be sufficient.

The fix is to insert the following directly under `runs-on: ubuntu-latest` (which is line 38 in this job):

```yaml
permissions:
  contents: read
```

No new methods, imports, or definitions are required for this change. Only the workflow YAML file is modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
