### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -63,6 +63,8 @@ jobs:
     needs:
       - test_pull_request
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       created_release_version: ${{ steps.get_release_hot_version.outputs.result }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/7](https://github.com/vorobalek/autobackend/security/code-scanning/7)

To fix the issue, add a `permissions` block to the `create_release_hot` job under `.github/workflows/pull_request.yml`, specifying the minimal necessary privileges. Since the job uses `actions/github-script` to call the REST API (`github.rest.repos.getLatestRelease`) which reads releases data, it needs at least `contents: read`. This matches the permissions assigned to analogous jobs in the same file, like `verify_release_notes` and `build_package_hot`. Place the following under `runs-on: ubuntu-latest` and above `steps:` in the `create_release_hot` job:

```yaml
permissions:
  contents: read
```

No other changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
