### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   verify_tag:
     name: Verify tag 'release-*' on the head
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/12](https://github.com/vorobalek/autobackend/security/code-scanning/12)

The recommended fix is to add a `permissions` block to the `verify_tag` job, matching the minimal permission used in the other jobs (i.e., `contents: read`). This should be inserted between `runs-on: ubuntu-latest` and `steps:` (lines 12–14 in the shown snippet). No other code needs to change, as this does not affect functionality. No imports or package installations are required; the change is purely in workflow configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
