### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,6 +145,8 @@ jobs:
       - create_release_hot
       - build_package_hot
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Setup


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/8](https://github.com/vorobalek/autobackend/security/code-scanning/8)

The fix is to add a `permissions` block to the `publish_myget_hot` job in `.github/workflows/pull_request.yml`, explicitly restricting the permissions of the `GITHUB_TOKEN`. Since this job does not interact with the GitHub API (like creating comments or uploading artifacts), the minimal required permission is `contents: read`. Insert the following block under the job's `runs-on` line (after line 147):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or adjustments are needed, as this simply restricts the token rights available to the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
