### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_dev.yml
+++ b/.github/workflows/release_dev.yml
@@ -120,6 +120,8 @@ jobs:
       - create_release_dev
       - build_package_dev
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Setup


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/9](https://github.com/vorobalek/autobackend/security/code-scanning/9)

The best way to fix the problem is to add a `permissions` block to the `publish_myget_dev` job within the `.github/workflows/release_dev.yml` file. Since the job appears to only publish a package to MyGet and does not interact with repository contents in a write capacity, we should assign it the minimal set of privileges—typically `contents: read` as a baseline. This change is made by inserting the block:

```yaml
permissions:
  contents: read
```

right after the `runs-on` statement for the relevant job (just like in other jobs in the workflow). No imports or additional definitions are required; it is an in-place YAML block addition, mirroring what is done in `test_release_dev`, `create_release_dev`, and `build_package_dev`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
