### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,8 @@ jobs:
       - create_release
       - build_package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Setup


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/10](https://github.com/vorobalek/autobackend/security/code-scanning/10)

To fix the problem, we need to add an explicit `permissions` block to the `publish_myget` job in the `.github/workflows/release.yml` file. This block should specify the least privilege necessary, which in this case is likely `contents: read`, as the job only publishes a package to MyGet and does not need write access to GitHub contents, deployments, issues, or packages. The new block should be inserted above the `steps:` key for the `publish_myget` job, matching the pattern used elsewhere in the workflow (cf. `build_package`, `publish_github`). No additional imports or methods are required, as this is a configuration change to the workflow YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
