### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,6 +227,8 @@ jobs:
       - create_release
       - build_package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Setup


### PR DESCRIPTION
Potential fix for [https://github.com/vorobalek/autobackend/security/code-scanning/11](https://github.com/vorobalek/autobackend/security/code-scanning/11)

To fix this issue, add an explicit `permissions` block to the `publish_nuget` job within `.github/workflows/release.yml`. Since the job only interacts with an external NuGet feed (using an external API key, not GITHUB_TOKEN), it should be given the minimal possible permissions—`contents: read`, which only allows the job to read repo contents but not write or perform any other privileged actions. Edit the region corresponding to `publish_nuget` to insert a `permissions:` key (at the same level as `runs-on`), setting `contents: read`.

No new methods or imports are required; just insert this block to limit GITHUB_TOKEN exposure for the job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
